### PR TITLE
Non-numeric survey IDs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 
-##Decipher API
+## Decipher API
 
 This package provides a PHP wrapper for the FocusVision Decipher API, along with binding for using it in Laravel applications.
 

--- a/src/Decipher.php
+++ b/src/Decipher.php
@@ -24,7 +24,7 @@ class Decipher
         return $this;
     }
 
-    public function setSurveyId(int $survey_id)
+    public function setSurveyId(string $survey_id)
     {
         $this->survey_id = $survey_id;
         return $this;


### PR DESCRIPTION
Decipher allows non-numeric survey IDs; this PR allows working with surveys having such IDs.