### PR TITLE
Feature/survey files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,4 +78,5 @@ try {
 - setSurveyId(int $id) - Set the ID of the current survey to work with.
 - setCondition(string $condition) - Condition required to retrieve the participant. This is a Python condition as if you would enter in survey logic or crosstabs. For example, “qualified and q3.r2” retrieves only participants that were qualified and answered q3 as r2.
 - getSurveyStructure(string $format) - Retrieve the structure of available questions for a survey, returning htem in the specified format.  Valid formats are: html, json, text, tab
-- getSurveyData(array $fields = ['all'], string $format = 'json') - Retrieve the responses to the question IDs passed in $fields from Decipher.  Note: uuid & status fields will always be returned. Any condition set using ::setCondition() will be applied 
+- getSurveyData(array $fields = ['all'], string $format = 'json') - Retrieve the responses to the question IDs passed in $fields from Decipher.  Note: uuid & status fields will always be returned. Any condition set using ::setCondition() will be applied
+- getSurveyFile(string $filename) - Retrieve the survey file called $filename as a string. 

--- a/src/Decipher.php
+++ b/src/Decipher.php
@@ -5,6 +5,7 @@ namespace MrDth\DecipherApi;
 use MrDth\DecipherApi\Exceptions\ServerDirectoryNotSetException;
 use MrDth\DecipherApi\Exceptions\SurveyIdNotSetException;
 use MrDth\DecipherApi\Factories\Api\SurveyData;
+use MrDth\DecipherApi\Factories\Api\SurveyFile;
 use MrDth\DecipherApi\Factories\Api\SurveyList;
 use MrDth\DecipherApi\Factories\Api\SurveyStructure;
 use MrDth\DecipherApi\Factories\Client;
@@ -72,6 +73,15 @@ class Decipher
         $client = new SurveyStructure($this->client, $this->server_directory, $this->survey_id);
 
         return $client->fetch($format);
+    }
+
+    public function getSurveyFile($filename)
+    {
+        $this->checkRequiredPropertiesExist();
+
+        $client = new SurveyFile($this->client, $this->server_directory, $this->survey_id);
+
+        return $client->fetch($filename);
     }
 
     protected function prepareFields(array $fields)

--- a/src/Factories/Api/SurveyFile.php
+++ b/src/Factories/Api/SurveyFile.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MrDth\DecipherApi\Factories\Api;
+
+use MrDth\DecipherApi\Factories\Client;
+
+class SurveyFile {
+
+    private $client;
+    private $survey_id;
+    private $server_directory;
+
+    public function __construct(Client $client, $server_directory, $survey_id)
+    {
+        $this->client = $client;
+        $this->server_directory = $server_directory;
+        $this->survey_id = $survey_id;
+    }
+
+    public function fetch(string $filename)
+    {
+        $response = $this->client->get($this->buildEndpoint($filename));
+
+        return (string) $response->getBody();
+    }
+
+    private function buildEndpoint(string $filename): string
+    {
+        return "surveys/$this->server_directory/$this->survey_id/files/$filename";
+    }
+}


### PR DESCRIPTION
This allows use of the API endpoint described here: https://release.decipherinc.com/s/local/api.html#survey-metadata-survey-file-access-get to fetch any of the files associated with a survey.